### PR TITLE
Rely on TTL timer to define wether or not start expiration window

### DIFF
--- a/lib/excess_flow/fixed_window_strategy.rb
+++ b/lib/excess_flow/fixed_window_strategy.rb
@@ -46,8 +46,12 @@ module ExcessFlow
       @current_requests ||= ExcessFlow.redis { |r| r.get(configuration.counter_key) }.to_i
     end
 
+    def current_ttl
+      @current_ttl ||= ExcessFlow.redis { |r| r.ttl(configuration.counter_key) }.to_i
+    end
+
     def start_expiration_window
-      return unless current_requests.zero?
+      return unless current_ttl.negative?
 
       ExcessFlow.redis { |r| r.expire(configuration.counter_key, configuration.ttl) }
     end

--- a/lib/excess_flow/sliding_window_strategy.rb
+++ b/lib/excess_flow/sliding_window_strategy.rb
@@ -60,12 +60,16 @@ module ExcessFlow
       @current_requests ||= ExcessFlow.redis { |r| r.zcount(configuration.counter_key, '-inf', '+inf') }
     end
 
+    def current_ttl
+      @current_ttl ||= ExcessFlow.redis { |r| r.ttl(configuration.counter_key) }.to_i
+    end
+
     def current_timestamp
       @current_timestamp ||= (Time.now.to_f * 100_000).to_i
     end
 
     def start_expiration_window
-      return if current_requests.zero?
+      return if current_ttl.negative?
 
       ExcessFlow.redis { |r| r.expire(configuration.counter_key, configuration.ttl) }
     end


### PR DESCRIPTION
`.expire` command on redis will return `false` if performed on top of a key that does not exist and `true` if key exists. `.ttl` on  other hand returns `-1` if key has no expiration and `-2` if key does not exist.

So this seems to be like a safe choice to go with so we can make rate limiting self-healing in case something taints the key.